### PR TITLE
Resolve a bug

### DIFF
--- a/Classes/Kit.php
+++ b/Classes/Kit.php
@@ -10,6 +10,13 @@ namespace Sohoa\Framework {
 
         public static function add($name, Kitable $instance)
         {
+            if (in_array($name, static::$_kitInit)) {
+                $key = array_keys(static::$_kitInit, $name);
+                $key = $key[0];
+
+                unset(static::$_kitInit[$key]);
+            }
+
             static::$_kits[$name] = $instance;
         }
 

--- a/Tests/Unit/Classes/Kit.php
+++ b/Tests/Unit/Classes/Kit.php
@@ -34,5 +34,33 @@ namespace Sohoa\Framework\Tests\Unit {
             $this->variable($kit->getView())->isNull();
 
         }
+        public function testLimitless()
+        {
+            _Kit::add('xyl', new Xyl());
+
+            $kit = new _Kit(new Http(), new Basic());
+
+            $this->sizeof($kit->getAllKits())->isEqualto(1);
+
+            $this->object($kit->kit('xyl'))->isInstanceOf('\Sohoa\Framework\Tests\Unit\Xyl');
+
+            $kit = $kit->kit('xyl');
+
+            $this->object($kit->getRouter())->isInstanceOf('\Hoa\Router\Http');
+            $this->variable($kit->getView())->isNull();
+
+
+            _Kit::add('xyl', new Xyl());
+            $kit = new _Kit(new Http(), new Basic());
+            $this->sizeof($kit->getAllKits())->isEqualto(1);
+
+            $this->object($kit->kit('xyl'))->isInstanceOf('\Sohoa\Framework\Tests\Unit\Xyl');
+
+            $kit = $kit->kit('xyl');
+
+            $this->object($kit->getRouter())->isInstanceOf('\Hoa\Router\Http');
+            $this->variable($kit->getView())->isNull();
+
+        }
     }
 }


### PR DESCRIPTION
Resolve a bug when we init-use an kit and want to reinit a kit on same identifier

Exemple

``` PHP
// index.php
kit::add('xyl' , new Xyl() );

// Controller/Main#IndexAction
$this->xyl->router; // \Sohoa\Framework\Router
$this->add('xyl' , new Xyl());
$this->xyl->router; // null
```

Ce comportement est peut être pas super naturel mais ca empeche pas, maintenant on aura bien

``` PHP
// index.php
kit::add('xyl' , new Xyl() );

// Controller/Main#IndexAction
$this->xyl->router; // \Sohoa\Framework\Router
$this->add('xyl' , new Xyl());
$this->xyl->router; // \Sohoa\Framework\Router
```
