### PR TITLE
Fix a bug with rules added by Hoa\Xyl.

### DIFF
--- a/Classes/Router.php
+++ b/Classes/Router.php
@@ -32,28 +32,35 @@ namespace Sohoa\Framework {
 
         public function __call($name, $arguments) {
 
-            $args = $arguments[1];
+            // private rules added by Hoa\Xyl should be handle by Hoa\Router itself
+            if('_' == $name[0]) {
 
-            if(!isset($args['as']))
-                throw new Exception('Missing as !');
-
-            if(!isset($args['to']))
-                throw new Exception('Missing to !');
-
-            if($name == 'any') {
-                $methods = self::$_methods;
+                parent::__call($name, $arguments);
             }
             else {
-                $methods = array($name);
+                $args = $arguments[1];
+
+                if(!isset($args['as']))
+                    throw new Exception('Missing as !');
+
+                if(!isset($args['to']))
+                    throw new Exception('Missing to !');
+
+                if($name == 'any') {
+                    $methods = self::$_methods;
+                }
+                else {
+                    $methods = array($name);
+                }
+
+                $to = explode('#', $args['to']);
+                $call = $to[0];
+                $able = $to[1];
+
+                $arguments = array($args['as'], $methods, $arguments[0], $call, $able);
+
+                return call_user_func_array(array($this, 'addRule'), $arguments);
             }
-
-            $to = explode('#', $args['to']);
-            $call = $to[0];
-            $able = $to[1];
-
-            $arguments = array($args['as'], $methods, $arguments[0], $call, $able);
-
-            return call_user_func_array(array($this, 'addRule'), $arguments);
         }
 
         public function resource($name, $args = array()) {

--- a/Tests/Unit/Classes/Router.php
+++ b/Tests/Unit/Classes/Router.php
@@ -75,7 +75,6 @@ class Router extends \atoum\test {
         $router->any('/test', array('as' => 'test', 'to' => 'Test#test'));
 
         $rule = $router->getRule('test');
-        $rule = $router->getRule('test');
         $this->rule($rule)
              ->methodIsEqualTo(array('get', 'post', 'put', 'delete'))
              ->callIsEqualTo('Test')
@@ -131,5 +130,20 @@ class Router extends \atoum\test {
                                 'editVehicles',
                                 'updateVehicles',
                                 'destroyVehicles'));
+    }
+
+    /**
+     * Hoa\Xyl add private rule to the router beginning with "_" so Sohoa\Router
+     * must be compatible with this behavior
+     */
+
+    public function testAddingAPrivateRule() {
+
+        $router = new \Sohoa\Framework\Router;
+        $router->_any('_resource', '/(?)/(?)');
+
+        $rule = $router->getRule('_resource');
+        $this->rule($rule)
+             ->methodIsEqualTo(array('get'));
     }
 }


### PR DESCRIPTION
Private rules (beginning with "_") are now forwarded to Hoa\Router.
