### PR TITLE
Generic route

### DIFF
--- a/Tests/Unit/Classes/Router.php
+++ b/Tests/Unit/Classes/Router.php
@@ -146,4 +146,14 @@ class Router extends \atoum\test {
         $this->rule($rule)
              ->methodIsEqualTo(array('get'));
     }
+
+    public function testAddGenericRule() {
+        $this
+            ->if($router = new \Sohoa\Framework\Router)
+            ->and($router->any('(?<controller>)(?<action>)'))
+                ->assert('Generic route has "generic" as id')
+                    ->boolean($router->ruleExists(\Sohoa\Framework\Router::ROUTE_GENERIC))
+                    ->isTrue();
+
+    }
 }


### PR DESCRIPTION
First try to implement the generic route in Sohoa
This allows to use the following code in Sohoa/Config/Route.php :
    $router->any(Sohoa\Framework\Router::ROUTE_GENERIC);
    // or it accepts a less magical solution
    $router->any('(?&lt;controller&gt;.[^/]+)/(?&lt;action&gt;.*)');

A third optionnal part is grabbed as well call "param" (not yet injected into controller) like this :
    $router->any('(?&lt;controller&gt;.[^/]+)/(?&lt;action&gt;.*)(?:/(?&lt;param&gt;.+)|/)?');

It is possible to defined a default action like this :
    $router->setDefaultAction('index');
That allows to have a generic route with a uri like http://domain/user/42 which calls Application/Controller/User::index()
